### PR TITLE
Update OpenPhish feed URL to new GitHub location

### DIFF
--- a/src/feeder/openfish_feed_downloader.py
+++ b/src/feeder/openfish_feed_downloader.py
@@ -7,6 +7,6 @@ from src.feeder.feed_downloader import FeedDownloader
 
 class OpenPhishFeedDownloader(FeedDownloader):
     def fetch(self) -> List[Url]:
-        openphish_url = "https://openphish.com/feed.txt"
+        openphish_url = "https://raw.githubusercontent.com/openphish/public_feed/refs/heads/main/feed.txt"
         malicious_urls = requests.get(openphish_url).content.decode('utf-8').split('\n')
         return [Url(url, 'OpenPhish', 'Malicious', "Phishing") for url in malicious_urls]


### PR DESCRIPTION
This PR updates the OpenPhish feed URL to point to their new GitHub-hosted location.

The original feed URL occasionally becomes unavailable, while the GitHub-based feed is now officially listed as a reliable alternative.

Switching to the GitHub feed ensures better reliability and availability of threat intelligence data.